### PR TITLE
Properly capitalize 'c' in groupChat

### DIFF
--- a/appPackage/manifest.json
+++ b/appPackage/manifest.json
@@ -91,7 +91,7 @@
             "canUpdateConfiguration": true,
             "scopes": [
                 "team",
-                "groupchat"
+                "groupChat"
             ],
             "context": [
                 "channelTab",


### PR DESCRIPTION
This fixes the issue #13. The manifest schema referenced by the manifest in this project does not allow for a lower-case 'c' in `groupChat`.