### PR TITLE
Set ADDIN_DOMAIN variable to appropriate endpoint

### DIFF
--- a/appPackage/manifest.json
+++ b/appPackage/manifest.json
@@ -137,8 +137,8 @@
                     "id": "runtime_1",
                     "type": "general",
                     "code": {
-                        "page": "https://localhost:53000/commands.html",
-                        "script": "https://localhost:53000/commands.js"
+                        "page": "${{ADDIN_ENDPOINT}}/commands.html",
+                        "script": "${{ADDIN_ENDPOINT}}/commands.js"
                     },
                     "lifetime": "short",
                     "actions": [
@@ -176,7 +176,7 @@
                     "id": "runtime_2",
                     "type": "general",
                     "code": {
-                        "page": "https://localhost:53000/taskpane.html"
+                        "page": "${{ADDIN_ENDPOINT}}/taskpane.html"
                     },
                     "lifetime": "short",
                     "actions": [
@@ -231,15 +231,15 @@
                                             "icons": [
                                                 {
                                                     "size": 16,
-                                                    "file": "https://localhost:53000/assets/icon-16.png"
+                                                    "file": "${{ADDIN_ENDPOINT}}/assets/icon-16.png"
                                                 },
                                                 {
                                                     "size": 32,
-                                                    "file": "https://localhost:53000/assets/icon-32.png"
+                                                    "file": "${{ADDIN_ENDPOINT}}/assets/icon-32.png"
                                                 },
                                                 {
                                                     "size": 80,
-                                                    "file": "https://localhost:53000/assets/icon-80.png"
+                                                    "file": "${{ADDIN_ENDPOINT}}/assets/icon-80.png"
                                                 }
                                             ],
                                             "supertip": {
@@ -290,15 +290,15 @@
                                             "icons": [
                                                 {
                                                     "size": 16,
-                                                    "file": "https://localhost:53000/assets/icon-16_02.png"
+                                                    "file": "${{ADDIN_ENDPOINT}}/assets/icon-16_02.png"
                                                 },
                                                 {
                                                     "size": 32,
-                                                    "file": "https://localhost:53000/assets/icon-32_02.png"
+                                                    "file": "${{ADDIN_ENDPOINT}}/assets/icon-32_02.png"
                                                 },
                                                 {
                                                     "size": 80,
-                                                    "file": "https://localhost:53000/assets/icon-80_02.png"
+                                                    "file": "${{ADDIN_ENDPOINT}}/assets/icon-80_02.png"
                                                 }
                                             ],
                                             "supertip": {
@@ -355,7 +355,7 @@
                     ]
                 }
             ],
-            "audienceClaimUrl": "https://localhost:53000/taskpane.html"
+            "audienceClaimUrl": "${{ADDIN_ENDPOINT}}/taskpane.html"
         }
     ]
 }

--- a/teamsapp.local.yml
+++ b/teamsapp.local.yml
@@ -11,7 +11,7 @@ provision:
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53001"
+      run: echo "::set-output TAB_ENDPOINT=https://${{TAB_DOMAIN}}"
   - uses: script
     name: Set ADDIN_DOMAIN for local launch
     with:

--- a/teamsapp.local.yml
+++ b/teamsapp.local.yml
@@ -12,6 +12,14 @@ provision:
     name: Set TAB_ENDPOINT for local launch
     with:
       run: echo "::set-output TAB_ENDPOINT=https://localhost:53001"
+  - uses: script
+    name: Set ADDIN_DOMAIN for local launch
+    with:
+      run: echo "::set-output ADDIN_DOMAIN=localhost:53000"
+  - uses: script
+    name: Set ADDIN_ENDPOINT for local launch
+    with:
+      run: echo "::set-output ADDIN_ENDPOINT=https://${{ADDIN_DOMAIN}}"
   - uses: teamsApp/create # Creates a Teams app
     with:
       name: NorthwindSuppliers-${{TEAMSFX_ENV}} # Teams app name


### PR DESCRIPTION
The ADDIN_DOMAIN variable was being referenced in the manifest but was never being set anywhere (Issue #12).

In this change, I also updated all the hardcoded uses of the add-in domain in the manifest to leverage the variable via a new ADDIN_ENDPOINT variable. Similarly, I updated TAB_ENDPOINT to reference TAB_DOMAIN to reduce duplication.